### PR TITLE
Fix "free variable vuiet--make-generator"

### DIFF
--- a/vuiet.el
+++ b/vuiet.el
@@ -36,6 +36,7 @@
 (require 'cl-lib)
 (require 'bind-key)
 (require 'mpv)
+(require 'generator)
 
 (defgroup vuiet ()
   "Emacs music player."


### PR DESCRIPTION
Hi,

I had some problems when loading and/or byte-compiling vuiet.el about undefined symbols, and `vuiet--make-generator` was the one that was breaking it.

Since it uses `iter-defun`, the `generator` library has to be loaded first, otherwise everything is marked as undefined.