### PR TITLE
Consider using of exact search by title of a track

### DIFF
--- a/vuiet.el
+++ b/vuiet.el
@@ -505,7 +505,8 @@ See `versuri-display' for the active keybindings inside this buffer."
                  #'vuiet--scrobble-track track))
   (mpv-start
    "--no-video"
-   (format "ytdl://ytsearch:%s" (vuiet--track-as-string track))))
+   (format "ytdl://ytsearch:%s title:\"%s\""
+            (vuiet-track-artist track) (vuiet-track-name track))))
 
 (defun vuiet--next-track (tracks)
   "Yield the next VUIET-TRACK object from the TRACKS list.


### PR DESCRIPTION
For example when searching by `danny baranowsky The Binding of Isaac`:
```
 youtube-dl ytsearch:"danny baranowsky The Binding of Isaac"
 downloaded -> Danny Baranowsky - The Binding of Isaac - 01 - Those Responsible-FPT7YzewleY.mp4
```
This is the wrong track.
When searching by `danny baranowsky title:"The Binding of Isaac"` the correct one is downloaded

```
youtube-dl ytsearch:"danny baranowsky title:\"The Binding of Isaac\""
downloaded -> The Binding Of Isaac - Main theme ( Danny Baranowsky )-OE8054tUkGk.mp4

```