### PR TITLE
Fix using symbol t as a variable

### DIFF
--- a/vuiet.el
+++ b/vuiet.el
@@ -769,8 +769,8 @@ from the given ARTIST."
   (unless random
     (setf random (y-or-n-p "Play random? ")))
   (vuiet-play
-   (seq-filter (lambda (t)
-                 (string-match artist (car t)))
+   (seq-filter (lambda (item)
+                 (string-match artist (car item)))
                (lastfm-user-get-loved-tracks
                 :limit vuiet-loved-tracks-limit))
    :random random))


### PR DESCRIPTION
When byte compiling, the use of `t` as a variable triggers this error:

    vuiet.el:759:1:Warning: Lexical argument shadows the dynamic variable t
    vuiet.el:773:25:Error: Invalid lambda variable t

According to the manual, *In Emacs Lisp, nil and t are special symbols that always evaluate to themselves*.