### PR TITLE
Add possibility to pause and continue with mpv.

### DIFF
--- a/vuiet.el
+++ b/vuiet.el
@@ -554,16 +554,28 @@ It only considers tracks from the current playlist."
     (browse-url
      (format "https://www.youtube.com/results?search_query=%s" it))))
 
+(defun vuiet--youtube-link-at-position ()
+"Return youtube link of the current track at the playback position."
+  (concat "https://www.youtube.com/"
+  	  (mpv-get-property "filename")
+  	  "&t=" (int-to-string
+		 (round (mpv-get-playback-position)))))
+
 (defun vuiet-playing-track-continue-on-youtube ()
   "Pause vuiet and continue playing on youtube."
   (interactive)
   (vuiet-play-pause)
   (when (vuiet-playing-artist)
     (browse-url
-     (concat "https://www.youtube.com/watch?v="
-             (mpv-get-property "filename")
-             "&t=" (int-to-string
-                    (round (mpv-get-playback-position)))))))
+     (vuiet--youtube-link-at-position))))
+
+(defun vuiet-playing-track-continue-with-mpv ()
+  "Pause vuiet and continue playing with mpv as a new process."
+  (interactive)
+  (vuiet-play-pause)
+  (when (vuiet-playing-artist)
+    (start-process "vuiet" nil "mpv"
+		   (vuiet--youtube-link-at-position))))
 
 (defun vuiet-artist-lastfm-page (artist)
   "Visit the ARTIST lastfm page."


### PR DESCRIPTION
- Separate the common part of `vuiet-playing-track-continue-with-mpv` and
`vuiet-playing-track-continue-on-youtube` as an internal function `vuiet--youtube-link-at-position`.

Fix #44. Also Fix #36.