### PR TITLE
Simplify vuiet-seek-(backward/foward)-rate with builtin mpv command

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,13 +317,13 @@ option). You should have both of them installed.
 
     Get the music player volume, between 0% and 100%.
     
-**vuiet-player-volume-inc**
+**vuiet-player-volume-inc** *(arg)*
 
-    Increase the music player volume by STEP percent.
+    Increase the music player volume by ARG percent.  ARG defaults to 10%.
 
-**vuiet-player-volume-dec**
+**vuiet-player-volume-dec** *(arg)*
     
-    Decrease the music player volume by STEP percent.
+    Decrease the music player volume by ARG percent.  ARG defaults to 10%.
     
 **vuiet-playing-artist-info**
 

--- a/vuiet.el
+++ b/vuiet.el
@@ -507,13 +507,15 @@ It only considers tracks from the current playlist."
 (defun vuiet-seek-backward (arg)
   "Seek backward the given number of ARG.  ARG defaults to 5 seconds."
   (interactive "p")
-  (mpv-seek-backward (if current-prefix-arg arg 5))
+  (or arg (setq arg 5))
+  (mpv-seek-backward arg)
   (vuiet-update-mode-line))
 
 (defun vuiet-seek-forward (arg)
   "Seek forward the given number of ARG.  ARG defaults to 5 seconds."
   (interactive "p")
-  (mpv-seek-forward (if current-prefix-arg arg 5))
+  (or arg (setq arg 5))
+  (mpv-seek-forward arg)
   (vuiet-update-mode-line))
 
 (defun vuiet-seek-backward-rate (arg)

--- a/vuiet.el
+++ b/vuiet.el
@@ -518,15 +518,13 @@ It only considers tracks from the current playlist."
 (defun vuiet-seek-backward-rate (arg)
   "Seek backward ARG% of the track.  ARG defaults to 10%."
   (interactive "p")
-  (mpv-seek-backward (round (* (if current-prefix-arg arg 10)
-			       (/ (mpv-get-duration) 100))))
+  (mpv-run-command "seek" (- (if current-prefix-arg arg 10)) "relative-percent")
   (vuiet-update-mode-line))
 
 (defun vuiet-seek-forward-rate (arg)
   "Seek forward ARG% of the track.  ARG defaults to 10%."
   (interactive "p")
-  (mpv-seek-forward (round (* (if current-prefix-arg arg 10)
-			      (/ (mpv-get-duration) 100))))
+  (mpv-run-command "seek" (if current-prefix-arg arg 10) "relative-percent")
   (vuiet-update-mode-line))
 
 (defun vuiet-play-pause ()

--- a/vuiet.el
+++ b/vuiet.el
@@ -518,13 +518,15 @@ It only considers tracks from the current playlist."
 (defun vuiet-seek-backward-rate (arg)
   "Seek backward ARG% of the track.  ARG defaults to 10%."
   (interactive "p")
-  (mpv-run-command "seek" (- (if current-prefix-arg arg 10)) "relative-percent")
+  (or arg (setq arg 10))
+  (mpv-run-command "seek" (- arg) "relative-percent")
   (vuiet-update-mode-line))
 
 (defun vuiet-seek-forward-rate (arg)
   "Seek forward ARG% of the track.  ARG defaults to 10%."
   (interactive "p")
-  (mpv-run-command "seek" (if current-prefix-arg arg 10) "relative-percent")
+  (or arg (setq arg 10))
+  (mpv-run-command "seek" arg "relative-percent")
   (vuiet-update-mode-line))
 
 (defun vuiet-play-pause ()
@@ -537,19 +539,21 @@ It only considers tracks from the current playlist."
   "Get the music player volume, between 0% and 100%."
   (mpv-get-property "volume"))
 
-(cl-defun vuiet-player-volume-inc (&key (step 1))
-  "Increase the music player volume by STEP percent."
-  (interactive)
+(defun vuiet-player-volume-inc (arg)
+  "Increase the music player volume by ARG percent.  ARG defaults to 10."
+  (interactive "p")
+  (or arg (setq arg 10))
   (let* ((volume (vuiet-player-volume))
-         (new-volume (+ volume step)))
+	 (new-volume (+ volume arg)))
     (when (<= new-volume 100)
       (mpv-set-property "volume" new-volume))))
 
-(cl-defun vuiet-player-volume-dec (&key (step 1))
-  "Decrease the mpv player volume by STEP percent."
-  (interactive)
+(defun vuiet-player-volume-dec (arg)
+  "Decrease the mpv player volume by ARG percent.  ARG defaults to 10."
+  (interactive "p")
+  (or arg (setq arg 10))
   (let* ((volume (vuiet-player-volume))
-         (new-volume (- volume step)))
+	 (new-volume (- volume arg)))
     (when (>= new-volume 0)
       (mpv-set-property "volume" new-volume))))
 

--- a/vuiet.el
+++ b/vuiet.el
@@ -504,32 +504,28 @@ It only considers tracks from the current playlist."
   (mpv-seek 1)
   (vuiet-update-mode-line))
 
-(defun vuiet-seek-backward (arg)
-  "Seek backward the given number of ARG.  ARG defaults to 5 seconds."
-  (interactive "p")
-  (or arg (setq arg 5))
-  (mpv-seek-backward arg)
+(defun vuiet-seek-backward (&optional arg)
+  "Seek backward ARG seconds.  ARG defaults to 5."
+  (interactive "P")
+  (mpv-seek-backward (or arg 5))
   (vuiet-update-mode-line))
 
-(defun vuiet-seek-forward (arg)
-  "Seek forward the given number of ARG.  ARG defaults to 5 seconds."
-  (interactive "p")
-  (or arg (setq arg 5))
-  (mpv-seek-forward arg)
+(defun vuiet-seek-forward (&optional arg)
+  "Seek forward ARG seconds.  ARG defaults to 5."
+  (interactive "P")
+  (mpv-seek-forward (or arg 5))
   (vuiet-update-mode-line))
 
-(defun vuiet-seek-backward-rate (arg)
-  "Seek backward ARG% of the track.  ARG defaults to 10%."
-  (interactive "p")
-  (or arg (setq arg 10))
-  (mpv-run-command "seek" (- arg) "relative-percent")
+(defun vuiet-seek-backward-rate (&optional arg)
+  "Seek backward ARG percents of the track.  ARG defaults to 10."
+  (interactive "P")
+  (mpv-run-command "seek" (- (or arg 10)) "relative-percent")
   (vuiet-update-mode-line))
 
-(defun vuiet-seek-forward-rate (arg)
-  "Seek forward ARG% of the track.  ARG defaults to 10%."
-  (interactive "p")
-  (or arg (setq arg 10))
-  (mpv-run-command "seek" arg "relative-percent")
+(defun vuiet-seek-forward-rate (&optional arg)
+  "Seek forward ARG percents of the track.  ARG defaults to 10."
+  (interactive "P")
+  (mpv-run-command "seek" (or arg 10) "relative-percent")
   (vuiet-update-mode-line))
 
 (defun vuiet-play-pause ()
@@ -542,21 +538,19 @@ It only considers tracks from the current playlist."
   "Get the music player volume, between 0% and 100%."
   (mpv-get-property "volume"))
 
-(defun vuiet-player-volume-inc (arg)
+(defun vuiet-player-volume-inc (&optional arg)
   "Increase the music player volume by ARG percent.  ARG defaults to 10."
-  (interactive "p")
-  (or arg (setq arg 10))
+  (interactive "P")
   (let* ((volume (vuiet-player-volume))
-	 (new-volume (+ volume arg)))
+	 (new-volume (+ volume (or arg 10))))
     (when (<= new-volume 100)
       (mpv-set-property "volume" new-volume))))
 
-(defun vuiet-player-volume-dec (arg)
+(defun vuiet-player-volume-dec (&optional arg)
   "Decrease the mpv player volume by ARG percent.  ARG defaults to 10."
-  (interactive "p")
-  (or arg (setq arg 10))
+  (interactive "P")
   (let* ((volume (vuiet-player-volume))
-	 (new-volume (- volume arg)))
+	 (new-volume (- volume (or arg 10))))
     (when (>= new-volume 0)
       (mpv-set-property "volume" new-volume))))
 


### PR DESCRIPTION
Sorry for the noise, but from mpv documentation I found out that there is a much more elegant way to implement those functions.